### PR TITLE
Add go.mod, gofmt

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -138,7 +138,7 @@ func EditPart(store *Secstore, line *liner.State, args []string) error {
 		return fmt.Errorf("'%s' is a directory.", args[0])
 	} else {
 		if data, err := OpenEditor(part.Data); err != nil {
-			return fmt.Errorf("Not saving. Error running editor:", err)
+			return fmt.Errorf("Not saving. Error running editor: %s", err)
 		} else {
 			part.Data = data
 			return nil
@@ -212,7 +212,7 @@ func MovePart(store *Secstore, line *liner.State, args []string) error {
 }
 
 func Help(store *Secstore, line *liner.State, args []string) error {
-	fmt.Println("Commands can be shortened, eg: quit can be called with q.\n")
+	fmt.Print("Commands can be shortened, eg: quit can be called with q.\n\n")
 	fmt.Println("chpass\t\tChange encryption password.")
 	fmt.Println("add name\tAdd a new password and start editing it.")
 	fmt.Println("mkdir name\tMake a new directory.")

--- a/commands.go
+++ b/commands.go
@@ -1,26 +1,27 @@
 package main
 
 import (
+	"crypto/rand"
 	"fmt"
 	"strings"
-	"crypto/rand"
+
 	"github.com/peterh/liner"
 )
 
 /* Be careful to not start any commands with q. */
-var Commands = map[string](func(*Secstore, *liner.State, []string) error) {
-	"chpass": 	ChangePass,
-	"add":		AddDataPart,
-	"mkdir":	AddDirPart,
-	"show":		ShowPart,
-	"ls":		ShowPart,
-	"rm":		RemovePart,
-	"edit":		EditPart,
-	"cd":		ChangeDir,
-	"mv":		MovePart,
-	"help":		Help,
-	"save":		Save,
-	"quit":		Quit,
+var Commands = map[string](func(*Secstore, *liner.State, []string) error){
+	"chpass": ChangePass,
+	"add":    AddDataPart,
+	"mkdir":  AddDirPart,
+	"show":   ShowPart,
+	"ls":     ShowPart,
+	"rm":     RemovePart,
+	"edit":   EditPart,
+	"cd":     ChangeDir,
+	"mv":     MovePart,
+	"help":   Help,
+	"save":   Save,
+	"quit":   Quit,
 }
 
 func randomPass() string {
@@ -33,25 +34,24 @@ func randomPass() string {
 
 	if err != nil {
 		return "Error generating random bytes!"
-	} 
+	}
 
 	sum = 0
 	for i := 0; i < len(b); i++ {
 		sum += int(b[i])
 		r = sum % 3
-		switch (r) {
+		switch r {
 		case 0:
-			b[i] = 'a' + b[i] % 26
+			b[i] = 'a' + b[i]%26
 		case 1:
-			b[i] = 'A' + b[i] % 26
+			b[i] = 'A' + b[i]%26
 		case 2:
-			b[i] = '0' + b[i] % 10
+			b[i] = '0' + b[i]%10
 		}
 	}
 
 	return string(b)
 }
-
 
 func ChangePass(store *Secstore, line *liner.State, args []string) error {
 	var pass []byte
@@ -68,7 +68,7 @@ func ChangePass(store *Secstore, line *liner.State, args []string) error {
 func ChangeDir(store *Secstore, line *liner.State, args []string) error {
 	var n *Part
 
-	if len (args) == 0 {
+	if len(args) == 0 {
 		store.Pwd = store.rootPart
 		return nil
 	} else if len(args) > 1 {
@@ -97,7 +97,7 @@ func RemovePart(store *Secstore, line *liner.State, args []string) error {
 			} else if part.Parent == nil {
 				return fmt.Errorf("Not removing root dir.")
 			}
-			
+
 			if err := part.Parent.RemovePart(part); err != nil {
 				return err
 			}
@@ -108,7 +108,7 @@ func RemovePart(store *Secstore, line *liner.State, args []string) error {
 
 func ShowPart(store *Secstore, line *liner.State, args []string) error {
 	var path []string
-	
+
 	if len(args) > 0 {
 		path = strings.Split(args[0], "/")
 	} else {
@@ -208,7 +208,7 @@ func MovePart(store *Secstore, line *liner.State, args []string) error {
 	dest.Data = old.Data
 	dest.SubParts = old.SubParts
 
-	return nil	
+	return nil
 }
 
 func Help(store *Secstore, line *liner.State, args []string) error {
@@ -240,7 +240,7 @@ func MatchCommand(cmd string) (func(*Secstore, *liner.State, []string) error, er
 	var f func(*Secstore, *liner.State, []string) error
 	var found bool = false
 
-	for c, g := range(Commands) {
+	for c, g := range Commands {
 		if strings.HasPrefix(c, cmd) {
 			if found {
 				return nil, fmt.Errorf("'%s' matched mulitple commands.", cmd)

--- a/decrypt.go
+++ b/decrypt.go
@@ -1,18 +1,18 @@
 package main
 
 import (
+	"crypto/aes"
 	"fmt"
 	"os"
 	"strings"
-	"crypto/aes"
 )
 
-var decryptionFuncs = map[string](func([]byte, []byte, *os.File) ([]byte, error)) {
-	"SecstorePass 0.1": 	VersionOne,
-	"store 02": 		VersionTwo,
+var decryptionFuncs = map[string](func([]byte, []byte, *os.File) ([]byte, error)){
+	"SecstorePass 0.1": VersionOne,
+	"store 02":         VersionTwo,
 }
 
-/* Decrypts first block with pass, checks it decrypted alright, then passes 
+/* Decrypts first block with pass, checks it decrypted alright, then passes
  * along to the proper decryption version. */
 func DecryptFile(pass []byte, file *os.File) ([]byte, error) {
 	var clear, cipher []byte
@@ -26,7 +26,7 @@ func DecryptFile(pass []byte, file *os.File) ([]byte, error) {
 	} else if err != nil {
 		return []byte(nil), err
 	}
-		
+
 	conv, err := aes.NewCipher(pass)
 	if err != nil {
 		return []byte(nil), err
@@ -35,7 +35,7 @@ func DecryptFile(pass []byte, file *os.File) ([]byte, error) {
 	conv.Decrypt(clear, cipher)
 
 	str := string(clear)
-	for header, function := range(decryptionFuncs) {
+	for header, function := range decryptionFuncs {
 		if strings.HasPrefix(str, header) {
 			bytes, err := function(pass, clear, file)
 			return bytes, err

--- a/edit.go
+++ b/edit.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"os/exec"
-	"math/rand"
 )
 
 func findValidTempFile(prefix string) string {
@@ -16,7 +16,7 @@ func findValidTempFile(prefix string) string {
 
 	rand.Seed(int64(rand.Int()))
 	for {
-		r := rand.Int() % 25 + int('a')
+		r := rand.Int()%25 + int('a')
 
 		path = append(path, byte(r))
 
@@ -52,7 +52,7 @@ func OpenEditor(data string) (string, error) {
 	file.Close()
 
 	/* Open editor */
-	
+
 	editor := os.Getenv("EDITOR")
 	if len(editor) == 0 {
 		editor = "vi"

--- a/encrypt.go
+++ b/encrypt.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"os"
 	"crypto/aes"
 	"crypto/rand"
+	"os"
 )
 
 var secstoreStart []byte = []byte("store 02")

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/mytchel/pass
+
+go 1.13
+
+require github.com/peterh/liner v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8BzLR4=
+github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/peterh/liner v1.1.0 h1:f+aAedNJA6uk7+6rXsYBnhdo4Xux7ESLe+kcuVUF5os=
+github.com/peterh/liner v1.1.0/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+
 	"github.com/peterh/liner"
 )
 
@@ -47,7 +48,7 @@ func SaveSecstore(store *Secstore) error {
 }
 
 func Exit(store *Secstore) {
-	
+
 }
 
 func main() {
@@ -99,9 +100,9 @@ func main() {
 
 	if err = secstore.DecryptFile(file); err != nil {
 		fmt.Fprintln(os.Stderr, "Error decrypting:", err)
-		os.Exit(1)		
+		os.Exit(1)
 	}
-	
+
 	file.Close()
 
 	args := flag.Args()
@@ -113,7 +114,7 @@ func main() {
 			fmt.Fprintln(os.Stderr, err)
 		}
 	}
-	
+
 	if err := SaveSecstore(secstore); err != nil {
 		fmt.Fprintln(os.Stderr, "Error saving:", err)
 		os.Exit(1)

--- a/one.go
+++ b/one.go
@@ -1,15 +1,15 @@
 package main
 
 import (
-	"os"
 	"crypto/aes"
+	"os"
 )
 
 func OneCreateNewPass(oldKey, bytes []byte) []byte {
 	var newKey, both []byte
 	var i, sum, start int
 
-	both = make([]byte, len(oldKey) + len(bytes))
+	both = make([]byte, len(oldKey)+len(bytes))
 	copy(both, oldKey)
 	copy(both[len(oldKey):], bytes)
 
@@ -46,7 +46,7 @@ func VersionOne(pass, clear []byte, file *os.File) ([]byte, error) {
 		} else if err != nil {
 			return []byte(nil), err
 		}
-		
+
 		conv, err := aes.NewCipher(blockpass)
 		if err != nil {
 			return []byte(nil), err
@@ -58,4 +58,3 @@ func VersionOne(pass, clear []byte, file *os.File) ([]byte, error) {
 
 	return plain, nil
 }
-

--- a/part.go
+++ b/part.go
@@ -5,15 +5,15 @@ import (
 )
 
 const (
-	TypeDir = 1
+	TypeDir  = 1
 	TypeData = 2
 )
 
 type Part struct {
 	Name string
-	
-	Type int
-	Data string
+
+	Type     int
+	Data     string
 	SubParts *Part
 
 	Parent, Next *Part
@@ -27,24 +27,26 @@ func ParsePart(bytes []byte, parent *Part) (*Part, int, error) {
 	part = new(Part)
 	part.Parent = parent
 
-	for j = 0; j < len(bytes) && bytes[j] != 0; j++ {}
+	for j = 0; j < len(bytes) && bytes[j] != 0; j++ {
+	}
 	if j == len(bytes) {
 		return nil, j, fmt.Errorf("Error parsing part: Reached end.")
 	}
 
 	part.Name = string(bytes[:j])
-	
-	for k = j + 1; k < len(bytes) && bytes[k] != 0; k++ {}
+
+	for k = j + 1; k < len(bytes) && bytes[k] != 0; k++ {
+	}
 	if k == len(bytes) {
 		return nil, k, fmt.Errorf("Error parsing part: Reached end.")
 	}
-	
-	/* Data part */
-	if k > j + 1 {
-		part.Type = TypeData
-		part.Data = string(bytes[j+1:k])
 
-	/* Sub tree */
+	/* Data part */
+	if k > j+1 {
+		part.Type = TypeData
+		part.Data = string(bytes[j+1 : k])
+
+		/* Sub tree */
 	} else {
 		part.Type = TypeDir
 		part.SubParts, j, err = ParseParts(bytes[k+1:], part)
@@ -64,7 +66,7 @@ func ParseParts(bytes []byte, parent *Part) (*Part, int, error) {
 
 	head = new(Part)
 	prev = head
-	
+
 	i = 0
 	for i < len(bytes) && bytes[i] != 0 {
 		part, j, err = ParsePart(bytes[i:], parent)
@@ -73,7 +75,7 @@ func ParseParts(bytes []byte, parent *Part) (*Part, int, error) {
 		}
 
 		i += j + 1
-		
+
 		prev.Next = part
 		prev = part
 	}
@@ -95,7 +97,7 @@ func (part *Part) ToBytes() []byte {
 	} else {
 		bytes = append(bytes, []byte(part.Data)...)
 	}
-	
+
 	bytes = append(bytes, 0)
 
 	return bytes
@@ -155,7 +157,8 @@ func (part *Part) AddPart(o *Part) error {
 	if part.SubParts == nil {
 		part.SubParts = o
 	} else {
-		for p = part.SubParts; p.Next != nil; p = p.Next {}
+		for p = part.SubParts; p.Next != nil; p = p.Next {
+		}
 		p.Next = o
 	}
 
@@ -172,7 +175,8 @@ func (part *Part) RemovePart(o *Part) error {
 	if part.SubParts == o {
 		part.SubParts = part.SubParts.Next
 	} else {
-		for p = part.SubParts; p.Next != o; p = p.Next {}
+		for p = part.SubParts; p.Next != o; p = p.Next {
+		}
 		p.Next = o.Next
 	}
 

--- a/password.go
+++ b/password.go
@@ -27,6 +27,7 @@ import "C"
 import (
 	"fmt"
 	"os"
+
 	"github.com/peterh/liner"
 )
 
@@ -86,4 +87,3 @@ func GetNewPass(line *liner.State) ([]byte, error) {
 		return nil, fmt.Errorf("Passwords did not match.")
 	}
 }
-

--- a/repl.go
+++ b/repl.go
@@ -3,8 +3,9 @@ package main
 import (
 	"fmt"
 	"os"
-	"unicode"
 	"strings"
+	"unicode"
+
 	"github.com/peterh/liner"
 )
 
@@ -22,7 +23,7 @@ func RunRepl(store *Secstore, line *liner.State) {
 		}
 
 		line.AppendHistory(l)
-		
+
 		sections = splitSections(l)
 
 		if len(sections) == 0 {
@@ -33,7 +34,7 @@ func RunRepl(store *Secstore, line *liner.State) {
 			err = EvalCommand(store, line, sections)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
-			} 
+			}
 		}
 	}
 }
@@ -42,7 +43,7 @@ func splitSections(s string) (sections []string) {
 	var i, j int
 	var quote bool = false
 	var section string
-	
+
 	i = 0
 	for i < len(s) {
 		section = ""
@@ -50,7 +51,7 @@ func splitSections(s string) (sections []string) {
 			if s[j] == '\'' {
 				quote = !quote
 			} else if unicode.IsSpace(rune(s[j])) && !quote {
-				break		
+				break
 			} else {
 				section = section + string(s[j])
 			}
@@ -60,7 +61,7 @@ func splitSections(s string) (sections []string) {
 
 		for i = j; i < len(s); i++ {
 			if !unicode.IsSpace(rune(s[i])) {
-				break		
+				break
 			}
 		}
 	}
@@ -89,7 +90,7 @@ func completer(line string) []string {
 	} else if len(sections) == 1 {
 		var matches []string = []string(nil)
 
-		for c, _ := range(Commands) {
+		for c, _ := range Commands {
 			if strings.HasPrefix(c, sections[0]) {
 				matches = append(matches, c)
 			}

--- a/secstore.go
+++ b/secstore.go
@@ -7,8 +7,8 @@ import (
 
 type Secstore struct {
 	rootPart *Part
-	Pwd *Part
-	Pass []byte
+	Pwd      *Part
+	Pass     []byte
 }
 
 func (store *Secstore) DecryptFile(file *os.File) error {
@@ -23,12 +23,12 @@ func (store *Secstore) DecryptFile(file *os.File) error {
 	store.rootPart = new(Part)
 	store.rootPart.Type = TypeDir
 	store.rootPart.Name = "/"
-	
+
 	store.rootPart.SubParts, _, err = ParseParts(plain, store.rootPart)
 	if err != nil {
 		return err
 	}
-	
+
 	store.Pwd = store.rootPart
 
 	return nil
@@ -50,9 +50,9 @@ func (store *Secstore) addPart(path []string) (*Part, error) {
 	if part = store.Pwd.FindSub(path); part != nil {
 		return nil, fmt.Errorf("'%s' already exists.", path)
 	}
-	
-	ppath := path[0:len(path) - 1]
-	name := path[len(path) - 1]
+
+	ppath := path[0 : len(path)-1]
+	name := path[len(path)-1]
 
 	if parent = store.Pwd.FindSub(ppath); parent == nil {
 		return nil, fmt.Errorf("Parent '%s' does not exist.", ppath)
@@ -67,4 +67,3 @@ func (store *Secstore) addPart(path []string) (*Part, error) {
 
 	return part, nil
 }
-

--- a/two.go
+++ b/two.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"os"
 	"crypto/aes"
+	"os"
 )
 
 func TwoCreateNewPass(oldKey, bytes []byte) []byte {
@@ -13,7 +13,7 @@ func TwoCreateNewPass(oldKey, bytes []byte) []byte {
 	copy(newKey, oldKey)
 
 	for i = 0; i < KeySize; i++ {
-		newKey[i] += bytes[i % len(bytes)]		
+		newKey[i] += bytes[i%len(bytes)]
 	}
 
 	return newKey
@@ -36,7 +36,7 @@ func VersionTwo(pass, clear []byte, file *os.File) ([]byte, error) {
 		} else if err != nil {
 			return []byte(nil), err
 		}
-		
+
 		conv, err := aes.NewCipher(blockpass)
 		if err != nil {
 			return []byte(nil), err
@@ -49,4 +49,3 @@ func VersionTwo(pass, clear []byte, file *os.File) ([]byte, error) {
 
 	return plain, nil
 }
-


### PR DESCRIPTION
Makes it possible to compile and work on it outside GOPATH. Also records
versions of dependencies.

Fixed two errors reported by "go vet" (which is run on "go test" since
Go 1.11):

	$ go test
	# github.com/mytchel/pass
	./commands.go:141:21: Errorf call has arguments but no formatting directives
	./commands.go:215:2: Println arg list ends with redundant newline

Also ran `goimports` on all files for the standard `gofmt`formatting.